### PR TITLE
Fix CLI input handling and cache integrity

### DIFF
--- a/docs/ARG_PASSING_AND_CACHE_FIX_REPORT.md
+++ b/docs/ARG_PASSING_AND_CACHE_FIX_REPORT.md
@@ -1,0 +1,32 @@
+# ARG Passing + Cache Integrity Fix Report
+
+## Root causes
+- **Input path handling was rigid**: the CLI always assumed inputs were basenames under `data/cvs/`, so explicit file paths or directories were misinterpreted or rejected. This blocked folder inputs and made `--output-path` behavior inconsistent when inputs were outside the default folder.
+- **Cache keys were not canonical**: cache entries were keyed by the string passed in, which could collide for files with identical basenames in different folders.
+- **Output path handling was directory-only**: `--output-path` was always treated as a directory, so providing a PDF file path did not work and skip checks were tied to the wrong location.
+- **Cache writes were non-atomic and updates happened even on failed builds**: cache writes could be interrupted and LaTeX failures still allowed cache updates.
+
+## What changed
+- Added robust input resolution, directory expansion, and de-duplication using canonical paths.
+- Implemented canonical cache keys (absolute + Windows case-folding) to prevent collisions.
+- Added output-path parsing rules to distinguish directories vs a single PDF target.
+- Enforced skip logic that requires both unchanged input hash and existing output PDF.
+- Added atomic cache writes and avoided cache updates on failed LaTeX runs.
+- Added regression tests to cover folder inputs, output-path rules, skip logic, and cache key uniqueness.
+
+## How to reproduce the old bug
+1. Run `python generate_cv.py data/cvs_temp` with a folder of JSON files; only the default folder was processed, and folders were not expanded.
+2. Run `python generate_cv.py data/cvs/ramin.json --output-path ./out.pdf`; the output path was treated as a directory, not a PDF target.
+3. Use two JSON files with the same name in different directories; cache entries could collide because they used non-canonical keys.
+
+## How to verify the fix
+- Run tests:
+  - `pytest`
+- Manual checks:
+  - `python generate_cv.py`
+  - `python generate_cv.py --output-path ./pdfs`
+  - `python generate_cv.py data/cvs_temp/ramin_en.json --output-path ./temp`
+  - `python generate_cv.py data/cvs_temp --output-path ./temp`
+
+## Notes about folder input behavior
+- Folder inputs are treated as **non-recursive** expansions of JSON files (case-insensitive `.json`). This matches the existing behavior where default processing lists only the direct contents of `data/cvs/`.

--- a/generate_cv.py
+++ b/generate_cv.py
@@ -58,11 +58,19 @@ def load_cache():
 
 def save_cache(cache):
     """Save the hash cache to the cache file."""
+    cache_path = Path(CACHE_FILE)
+    temp_path = cache_path.with_suffix(f"{cache_path.suffix}.tmp")
     try:
-        with open(CACHE_FILE, "w", encoding="utf-8") as f:
+        with open(temp_path, "w", encoding="utf-8") as f:
             json.dump(cache, f, indent=2)
+        temp_path.replace(cache_path)
     except IOError as e:
         print(f"⚠️  Warning: Could not save cache: {e}")
+        try:
+            if temp_path.exists():
+                temp_path.unlink()
+        except OSError:
+            pass
 
 
 def compute_file_hash(filepath):
@@ -77,19 +85,69 @@ def compute_file_hash(filepath):
         return None
 
 
-def has_file_changed(filepath, cache,output_path,pdf_name):
+def normalize_cache_key(filepath: Path) -> str:
+    resolved = filepath.resolve()
+    key = str(resolved)
+    if os.name == "nt":
+        return key.casefold()
+    return key
+
+
+def has_file_changed(filepath, cache, output_file: Path):
     """
     Check if a file has changed since last processing.
     
     Returns (changed: bool, current_hash: str)
     """
     current_hash = compute_file_hash(filepath)
-    if current_hash is None or not os.path.exists(os.path.join(output_path,pdf_name)):
+    if current_hash is None:
         return True, None
+    if not output_file.exists():
+        return True, current_hash
     
-    cached_hash = cache.get(filepath)
+    cached_hash = cache.get(normalize_cache_key(Path(filepath)))
     changed = cached_hash != current_hash
     return changed, current_hash
+
+
+def _run_latex(command: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(command, check=False, capture_output=True, text=True)
+
+
+def resolve_input_paths(args_files):
+    input_paths = []
+    for raw in args_files:
+        candidate = Path(raw)
+        if not candidate.exists():
+            fallback = Path(CVS_PATH) / raw
+            if fallback.exists():
+                candidate = fallback
+        input_paths.append(candidate)
+    return input_paths
+
+
+def expand_input_paths(paths):
+    expanded = []
+    for path in paths:
+        if path.is_dir():
+            for entry in sorted(path.iterdir()):
+                if entry.is_file() and entry.suffix.lower() == ".json":
+                    expanded.append(entry)
+        else:
+            expanded.append(path)
+    return expanded
+
+
+def dedupe_paths(paths):
+    seen = set()
+    deduped = []
+    for path in paths:
+        key = normalize_cache_key(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(path)
+    return deduped
 
 
 # -------------------------
@@ -176,7 +234,7 @@ def parse_cv_filename(filename):
     Returns (base_name, lang)
     """
     # Remove .json extension
-    name = filename[:-5] if filename.endswith('.json') else filename
+    name = filename[:-5] if filename.lower().endswith('.json') else filename
     
     # Pattern: name-lang or name_lang where lang is 2-3 lowercase letters
     match = re.match(r'^(.+?)[-_]([a-z]{2,3})$', name)
@@ -272,7 +330,14 @@ def make_tr_raw_filter(lang_map, lang):
 # -------------------------
 # Process Single CV File
 # -------------------------
-def process_cv_file(people, lang_map, section_templates, cache, output_path):
+def process_cv_file(
+    input_path: Path,
+    lang_map,
+    section_templates,
+    cache,
+    output_path: Path,
+    output_name_override: str | None = None,
+):
     """
     Process a single CV JSON file and generate PDF.
     
@@ -286,40 +351,39 @@ def process_cv_file(people, lang_map, section_templates, cache, output_path):
     Returns:
         tuple: (processed: bool, skipped: bool, current_hash: str or None)
     """
-    if not people.endswith('.json'):
-        log_verbose(f"  ⏭️  Skipping {people}: not a JSON file")
+    if input_path.suffix.lower() != ".json":
+        log_verbose(f"  ⏭️  Skipping {input_path}: not a JSON file")
         return False, True, None
     orig_output_path = output_path
     # Parse filename to get base_name and language
-    base_name, lang = parse_cv_filename(people)
+    base_name, lang = parse_cv_filename(input_path.name)
     is_rtl = lang in RTL_LANGUAGES
-    
-    JSON_PATH = os.path.join(CVS_PATH, people)
 
     # Check if file exists
-    if not os.path.exists(JSON_PATH):
-        print(f"❌ File not found: {JSON_PATH}")
+    if not input_path.exists():
+        print(f"❌ File not found: {input_path}")
         return False, False, None
-    pdf_name = f"{base_name}_{lang}.pdf"
+    pdf_name = output_name_override or f"{base_name}_{lang}.pdf"
+    output_file = output_path / pdf_name
 
     # Check if file has changed using cache
-    changed, current_hash = has_file_changed(JSON_PATH, cache,output_path,pdf_name)
+    changed, current_hash = has_file_changed(str(input_path), cache, output_file)
     if not changed:
-        log_verbose(f"  ⏭️  Skipping {people}: file unchanged (cached)")
-        print(f"⏭️  Skipping {people}: no changes detected")
+        log_verbose(f"  ⏭️  Skipping {input_path}: file unchanged (cached)")
+        print(f"⏭️  Skipping {input_path}: no changes detected")
         return False, True, current_hash
 
-    log_verbose(f"  📄 Processing {people} (base: {base_name}, lang: {lang}, RTL: {is_rtl})")
+    log_verbose(f"  📄 Processing {input_path} (base: {base_name}, lang: {lang}, RTL: {is_rtl})")
 
     # -------------------------
     # Load data (no eval, no hacks)
     # -------------------------
-    with open(JSON_PATH, encoding="utf-8") as f:
+    with open(input_path, encoding="utf-8") as f:
         data = json.load(f)
 
     # Validate required structure - skip files that don't have the expected schema
     if "basics" not in data:
-        print(f"⚠️  Skipping {people}: missing 'basics' key (incompatible schema)")
+        print(f"⚠️  Skipping {input_path}: missing 'basics' key (incompatible schema)")
         return False, True, None
 
     # Create output directory structure: result/<base_name>/<lang>/sections/
@@ -430,23 +494,46 @@ def process_cv_file(people, lang_map, section_templates, cache, output_path):
     print(f"➡️  Compile with: xelatex {RENDERED_OUTPUT}")
     
     # Generate PDF output name with language suffix
-    pdf_name = f"{base_name}_{lang}.pdf"
-    command = fr"xelatex -enable-etex -enable-installer -enable-mltex -interaction=nonstopmode -file-line-error -synctex=1 -output-directory={orig_output_path} {RENDERED_OUTPUT} "
+    pdf_name = output_name_override or f"{base_name}_{lang}.pdf"
+    command = [
+        "xelatex",
+        "-enable-etex",
+        "-enable-installer",
+        "-enable-mltex",
+        "-interaction=nonstopmode",
+        "-file-line-error",
+        "-synctex=1",
+        f"-output-directory={orig_output_path}",
+        RENDERED_OUTPUT,
+    ]
 
     # run the command to compile the LaTeX file
-    log_verbose(f"    🔧 Running: {command}")
-    os.system(command)
+    log_verbose(f"    🔧 Running: {' '.join(command)}")
+    result = _run_latex(command)
+    if result.returncode != 0:
+        print(f"❌ LaTeX compilation failed for {input_path}")
+        if VERBOSE:
+            print(result.stdout)
+            print(result.stderr)
+        return False, False, None
 
     # Handle output files
     output_dir = orig_output_path
-    if os.path.exists(output_dir):
-        for file in os.listdir(output_dir):
-            file_path = os.path.join(output_dir, file)
-            if not file.endswith(".pdf"):
-                os.remove(file_path)
-            if file.endswith("rendered.pdf"):
-                shutil.move(file_path, os.path.join(output_dir, pdf_name))
-                log_verbose(f"    📄 PDF generated: {pdf_name}")
+    if output_dir.exists():
+        rendered_pdf = output_dir / "rendered.pdf"
+        for file in output_dir.iterdir():
+            if (
+                file.is_file()
+                and file.name.startswith("rendered.")
+                and not file.name.endswith(".pdf")
+            ):
+                file.unlink()
+        if rendered_pdf.exists():
+            shutil.move(str(rendered_pdf), str(output_dir / pdf_name))
+            log_verbose(f"    📄 PDF generated: {pdf_name}")
+        else:
+            print(f"❌ Expected PDF not found for {input_path}")
+            return False, False, None
 
 
     return True, False, current_hash
@@ -494,13 +581,13 @@ Change Detection:
             "Optional: Directory or PDF file path to save generated PDFs. "
             "Defaults to the standard output folder."
         ),
-        default="./output"
+        default=str(Path(BASE_DIR) / "output")
 
     )
     
     args = parser.parse_args()
     VERBOSE = args.verbose
-    output_path = args.output_path
+    output_path = Path(args.output_path)
     
     log_verbose("🔧 Verbose mode enabled")
     log_verbose(f"📁 Base directory: {BASE_DIR}")
@@ -513,10 +600,20 @@ Change Detection:
         os.makedirs(RESULT_DIR)
         log_verbose(f"📁 Created result directory: {RESULT_DIR}")
     
-    output_dir = output_path
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-        log_verbose(f"📁 Created output directory: {output_dir}")
+    output_is_file = False
+    if output_path.exists():
+        output_is_file = output_path.is_file()
+    elif output_path.suffix.lower() == ".pdf":
+        output_is_file = True
+
+    if output_is_file:
+        output_dir = output_path.parent
+    else:
+        output_dir = output_path
+
+    output_dir = output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_verbose(f"📁 Output directory: {output_dir}")
     
     # Load the translation map once
     log_verbose("📖 Loading translation map...")
@@ -535,12 +632,21 @@ Change Detection:
     # Determine which files to process
     if args.files:
         # Process only specified files
-        files_to_process = args.files
+        resolved_inputs = resolve_input_paths(args.files)
+        files_to_process = expand_input_paths(resolved_inputs)
+        files_to_process = dedupe_paths(files_to_process)
         log_verbose(f"📋 Processing {len(files_to_process)} specified file(s)")
     else:
         # Process all JSON files in CVS_PATH
-        files_to_process = [f for f in os.listdir(CVS_PATH) if f.endswith('.json')]
+        files_to_process = [
+            path
+            for path in sorted(Path(CVS_PATH).iterdir())
+            if path.is_file() and path.suffix.lower() == ".json"
+        ]
         log_verbose(f"📋 Processing all {len(files_to_process)} JSON file(s) in {CVS_PATH}")
+
+    if output_is_file and len(files_to_process) != 1:
+        parser.error("--output-path points to a PDF file but multiple inputs were provided.")
 
     # Track statistics
     processed_count = 0
@@ -551,17 +657,16 @@ Change Detection:
     for people in files_to_process:
         log_verbose(f"\n{'='*50}")
         log_verbose(f"📄 Checking: {people}")
-        
+        output_name_override = output_path.name if output_is_file else None
         processed, skipped, current_hash = process_cv_file(
-            people, lang_map, section_templates, cache, output_path
+            Path(people), lang_map, section_templates, cache, output_dir, output_name_override
         )
 
         if processed:
             processed_count += 1
             # Update cache with new hash
-            json_path = os.path.join(CVS_PATH, people)
             if current_hash:
-                cache[json_path] = current_hash
+                cache[normalize_cache_key(Path(people))] = current_hash
                 log_verbose(f"    💾 Cache updated for {people}")
         elif skipped:
             skipped_count += 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_cli_paths.py
+++ b/tests/test_cli_paths.py
@@ -1,0 +1,223 @@
+import json
+import sys
+from pathlib import Path
+import types
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+jinja2_stub = types.ModuleType("jinja2")
+jinja2_exceptions_stub = types.ModuleType("jinja2.exceptions")
+
+
+class StubEnvironment:
+    def __init__(self, **kwargs):
+        self.filters = {}
+        self.globals = {}
+
+    def get_template(self, name):
+        class Template:
+            def render(self, _):
+                return "rendered"
+
+        return Template()
+
+
+class StubFileSystemLoader:
+    def __init__(self, path):
+        self.path = path
+
+
+class StubStrictUndefined:
+    pass
+
+
+class StubTemplateError(Exception):
+    pass
+
+
+jinja2_stub.Environment = StubEnvironment
+jinja2_stub.FileSystemLoader = StubFileSystemLoader
+jinja2_stub.StrictUndefined = StubStrictUndefined
+jinja2_exceptions_stub.TemplateError = StubTemplateError
+
+sys.modules["jinja2"] = jinja2_stub
+sys.modules["jinja2.exceptions"] = jinja2_exceptions_stub
+
+import generate_cv
+
+
+def setup_test_env(tmp_path, monkeypatch):
+    base_dir = tmp_path / "repo"
+    cvs_dir = base_dir / "data" / "cvs"
+    template_dir = base_dir / "templates"
+    lang_dir = base_dir / "Lang_engine"
+    result_dir = base_dir / "result"
+    cache_file = base_dir / ".cvgen_cache.json"
+
+    cvs_dir.mkdir(parents=True)
+    template_dir.mkdir(parents=True)
+    lang_dir.mkdir(parents=True)
+    result_dir.mkdir(parents=True)
+
+    (lang_dir / "lang.json").write_text(json.dumps({"dummy": {"en": "Dummy"}}))
+    (template_dir / "layout.tex").write_text("Test layout")
+    (template_dir / "header.tex").write_text("Header section")
+
+    monkeypatch.setattr(generate_cv, "BASE_DIR", str(base_dir))
+    monkeypatch.setattr(generate_cv, "CVS_PATH", str(cvs_dir))
+    monkeypatch.setattr(generate_cv, "TEMPLATE_DIR", str(template_dir))
+    monkeypatch.setattr(generate_cv, "LANG_ENGINE_DIR", str(lang_dir))
+    monkeypatch.setattr(generate_cv, "RESULT_DIR", str(result_dir))
+    monkeypatch.setattr(generate_cv, "CACHE_FILE", str(cache_file))
+    monkeypatch.setattr(generate_cv, "VERBOSE", False)
+
+    return {
+        "base_dir": base_dir,
+        "cvs_dir": cvs_dir,
+        "template_dir": template_dir,
+        "lang_dir": lang_dir,
+        "result_dir": result_dir,
+        "cache_file": cache_file,
+    }
+
+
+def fake_latex_runner(command):
+    output_arg = next(arg for arg in command if arg.startswith("-output-directory="))
+    output_dir = Path(output_arg.split("=", 1)[1])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "rendered.pdf").write_bytes(b"%PDF-1.4")
+    return generate_cv.subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+
+def create_cv_json(path: Path, name="Alice"):
+    data = {"basics": [{"fname": name, "lname": "Tester", "label": ["Engineer"]}]}
+    path.write_text(json.dumps(data))
+
+
+def test_folder_expansion_processes_json_only(tmp_path, monkeypatch):
+    env = setup_test_env(tmp_path, monkeypatch)
+    folder = env["base_dir"] / "inputs"
+    folder.mkdir()
+    create_cv_json(folder / "alice.json")
+    create_cv_json(folder / "bob.JSON")
+    (folder / "notes.txt").write_text("ignore")
+
+    output_dir = env["base_dir"] / "out"
+
+    monkeypatch.setattr(generate_cv, "_run_latex", fake_latex_runner)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["generate_cv.py", str(folder), "--output-path", str(output_dir)],
+    )
+
+    generate_cv.main()
+
+    assert (output_dir / "alice_en.pdf").exists()
+    assert (output_dir / "bob_en.pdf").exists()
+    assert not (output_dir / "notes.pdf").exists()
+
+
+def test_output_path_file_requires_single_input(tmp_path, monkeypatch):
+    env = setup_test_env(tmp_path, monkeypatch)
+    create_cv_json(env["cvs_dir"] / "one.json")
+    create_cv_json(env["cvs_dir"] / "two.json")
+    output_file = env["base_dir"] / "output.pdf"
+
+    monkeypatch.setattr(generate_cv, "_run_latex", fake_latex_runner)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate_cv.py",
+            str(env["cvs_dir"] / "one.json"),
+            str(env["cvs_dir"] / "two.json"),
+            "--output-path",
+            str(output_file),
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        generate_cv.main()
+
+
+def test_output_path_pdf_for_single_input(tmp_path, monkeypatch):
+    env = setup_test_env(tmp_path, monkeypatch)
+    cv_path = env["cvs_dir"] / "single.json"
+    create_cv_json(cv_path)
+    output_file = env["base_dir"] / "custom.pdf"
+
+    monkeypatch.setattr(generate_cv, "_run_latex", fake_latex_runner)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["generate_cv.py", str(cv_path), "--output-path", str(output_file)],
+    )
+
+    generate_cv.main()
+
+    assert output_file.exists()
+
+
+def test_cache_skip_and_regenerate_when_output_missing(tmp_path, monkeypatch):
+    env = setup_test_env(tmp_path, monkeypatch)
+    cv_path = env["cvs_dir"] / "skip.json"
+    create_cv_json(cv_path)
+
+    output_dir = env["base_dir"] / "out"
+    output_dir.mkdir()
+    cache = {}
+
+    run_count = {"value": 0}
+
+    def counting_runner(command):
+        run_count["value"] += 1
+        return fake_latex_runner(command)
+
+    monkeypatch.setattr(generate_cv, "_run_latex", counting_runner)
+
+    lang_map = generate_cv.load_lang_map()
+    section_templates = ["header.tex"]
+
+    processed, skipped, current_hash = generate_cv.process_cv_file(
+        cv_path, lang_map, section_templates, cache, output_dir
+    )
+    assert processed is True
+    cache[generate_cv.normalize_cache_key(cv_path)] = current_hash
+
+    processed, skipped, _ = generate_cv.process_cv_file(
+        cv_path, lang_map, section_templates, cache, output_dir
+    )
+    assert processed is False
+    assert skipped is True
+    assert run_count["value"] == 1
+
+    (output_dir / "skip_en.pdf").unlink()
+
+    processed, skipped, _ = generate_cv.process_cv_file(
+        cv_path, lang_map, section_templates, cache, output_dir
+    )
+    assert processed is True
+    assert skipped is False
+    assert run_count["value"] == 2
+
+
+def test_cache_key_dedupes_by_full_path(tmp_path, monkeypatch):
+    env = setup_test_env(tmp_path, monkeypatch)
+    dir_one = env["base_dir"] / "set1"
+    dir_two = env["base_dir"] / "set2"
+    dir_one.mkdir()
+    dir_two.mkdir()
+
+    file_one = dir_one / "shared.json"
+    file_two = dir_two / "shared.json"
+    create_cv_json(file_one)
+    create_cv_json(file_two)
+
+    key_one = generate_cv.normalize_cache_key(file_one)
+    key_two = generate_cv.normalize_cache_key(file_two)
+
+    assert key_one != key_two


### PR DESCRIPTION
### Motivation
- The CLI misinterpreted file and folder positional arguments and treated `--output-path` only as a directory, causing incorrect outputs and cache skips. 
- Cache keys used non-canonical strings which could collide for same basenames in different folders and allowed unsafe writes. 
- Folder inputs were not expanded correctly and skip logic did not require output PDF existence. 
- Preserve existing result/output separation and avoid changing architecture while making minimal, surgical fixes. 

### Description
- Normalize input path handling with `Path`-based resolution, expand directory inputs (non-recursive JSON-only), and dedupe canonical paths before processing. 
- Distinguish `--output-path` as directory vs single PDF target (error if PDF target set for multiple inputs) and support overriding output filename for single-file runs. 
- Harden cache semantics by using canonical cache keys (resolved path with Windows case-folding), require output PDF existence for skip, and make cache writes atomic (temp file + replace). 
- Add a lightweight LaTeX runner seam (`_run_latex`) using `subprocess.run`, avoid updating cache on failed builds, and add regression tests plus a report (`docs/ARG_PASSING_AND_CACHE_FIX_REPORT.md`). 

### Testing
- Added `tests/test_cli_paths.py` exercising folder expansion, output-path file/dir rules, cache dedupe, and skip/regenerate semantics, and limited pytest discovery via `pytest.ini`. 
- Ran `pytest -q` and all tests passed (`5 passed`). 
- Tests mock LaTeX invocation via a seam so they run without an actual `xelatex` binary. 
- Manual verification steps are documented in `docs/ARG_PASSING_AND_CACHE_FIX_REPORT.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696012f9409c8322ab1e005481249078)